### PR TITLE
Make bitset more completed. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.3)
 project(malloc)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -Wall -g")
 
 # add a build target for the module
 # use debug mode switch to turn on/off debug mode

--- a/bitmap/CMakeLists.txt
+++ b/bitmap/CMakeLists.txt
@@ -6,3 +6,4 @@ set(MODULE_NAME bitmap)
 BUILD_MODULE(${MODULE_NAME} ON)
 
 ADD_TEST_TARGET(bitmap_basic_tests ${MODULE_NAME})
+ADD_TEST_TARGET(bitmap_replay ${MODULE_NAME})

--- a/bitmap/bitmap.c
+++ b/bitmap/bitmap.c
@@ -26,7 +26,6 @@ SOFTWARE.
 #include <morecore.h>
 
 #include "bitmap.h"
-#include "bitset.h"
 
 static void *g_pheap;
 static size_t g_heap_size;
@@ -40,7 +39,7 @@ void bitmap_init(size_t size) {
 	g_pheap = morecore(size);
 	g_heap_size = size;
 	// the bitset will "borrow" some heap space here for the bit "score-board".
-	bs_init(&g_bset, size / (CHUNK_SIZE_IN_BITS * WORD_SIZE) + 1, g_pheap);
+	bs_init(&g_bset, size / (CHK_IN_BIT * WORD_SIZE) + 1, g_pheap);
 }
 
 void bitmap_release() {
@@ -52,18 +51,11 @@ void bitmap_release() {
  * amount of heap/mapped memory.
  * The size is round up to the word boundary.
  * NULL is returned when there is not enough memory.
- *
- * Algorithm:
- * During the scan, the program behave in two modes: cross mode
- * and non-cross mode. During cross mode, we are looking for a
- * run of n consecutive 0s cross the word boundary. And in
- * non-cross mode we expect to get our result within the current
- * word.
  */
 void *malloc(size_t size)
 {
 	size_t n = ALIGN_WORD_BOUNDARY(size);
-	int run_index = bs_nrun(&g_bset, n);
+	int run_index = bs_nrun(&g_bset, n / WORD_SIZE);
 	return g_pheap + run_index;
 }
 

--- a/bitmap/bitmap.c
+++ b/bitmap/bitmap.c
@@ -72,7 +72,7 @@ void *malloc(size_t size)
 	boundary[0] = BOUNDARY_TAG;
 	boundary[1] = (U32) num_bits;
 
-	return addr;
+	return addr + 1;
 }
 
 /*

--- a/bitmap/bitmap.h
+++ b/bitmap/bitmap.h
@@ -28,6 +28,8 @@ SOFTWARE.
 #include <stddef.h>
 #include <bitset.h>
 
+#define BOUNDARY_TAG        0xBBEEEEFF
+
 void bitmap_init(size_t size);
 void bitmap_release();
 

--- a/bitmap/bitmap.h
+++ b/bitmap/bitmap.h
@@ -26,7 +26,7 @@ SOFTWARE.
 #define MALLOC_BITMAP_H
 
 #include <stddef.h>
-#include <bitset.h>
+#include "bitset.h"
 
 #define BOUNDARY_TAG        0xBBEEEEFF
 

--- a/bitmap/bitmap_basic_tests.c
+++ b/bitmap/bitmap_basic_tests.c
@@ -40,7 +40,18 @@ static void teardown() {
 }
 
 void test_bitmap_init() {
-	assert_not_equal(g_pheap, malloc(10));
+	assert_equal(0xFF00000000000000, *((BITCHUNK *)g_pheap));
+}
+
+void test_bitmap_malloc() {
+	void *addr10 = malloc(10);
+	// check bit board
+	assert_equal(0xFFE0000000000000, *((BITCHUNK *)g_pheap));
+	// check address
+	assert_addr_equal(addr10, g_pheap + 8);
+	// check boundary tag
+	assert_equal(0xBBEEEEFF, *((U32 *)addr10));
+	assert_equal(3, ((U32 *)addr10)[1]);
 }
 
 int main(int argc, char *argv[]) {
@@ -48,6 +59,7 @@ int main(int argc, char *argv[]) {
 	cunit_teardown = teardown;
 
 	test(test_bitmap_init);
+	test(test_bitmap_malloc);
 
 	return 0;
 }

--- a/bitmap/bitmap_basic_tests.c
+++ b/bitmap/bitmap_basic_tests.c
@@ -22,30 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-/*
-The MIT License (MIT)
-
-Copyright (c) 2015 Terence Parr, Hanzhou Shi, Shuai Yuan, Yuanyuan Zhang
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
-
 #include <cunit.h>
 #include <string.h>
 #include "bitmap.h"

--- a/bitmap/bitmap_basic_tests.c
+++ b/bitmap/bitmap_basic_tests.c
@@ -48,10 +48,10 @@ void test_bitmap_malloc() {
 	// check bit board
 	assert_equal(0xFFE0000000000000, *((BITCHUNK *)g_pheap));
 	// check address
-	assert_addr_equal(addr10, g_pheap + 8);
+	assert_addr_equal(addr10, g_pheap + 8 + 1);
 	// check boundary tag
-	assert_equal(0xBBEEEEFF, *((U32 *)addr10));
-	assert_equal(3, ((U32 *)addr10)[1]);
+	assert_equal(0xBBEEEEFF, *((U32 *)(addr10 - 1)));
+	assert_equal(3, ((U32 *)(addr10 - 1))[1]);
 }
 
 int main(int argc, char *argv[]) {

--- a/bitmap/bitmap_basic_tests.c
+++ b/bitmap/bitmap_basic_tests.c
@@ -73,11 +73,24 @@ void test_bitmap_malloc_free() {
 	// check boundary tag
 	assert_equal(0xBBEEEEFF, *((U32 *)(WORD(addr100) - 1)));
 	assert_equal(14, ((U32 *)(WORD(addr100) - 1))[1]);
+	// test unsatisfiable request
+	assert_equal(NULL, malloc(4096));
 	///////////
 	// freeing
 	free(addr20);
-	// check bit board
 	assert_equal(0xFF0FFFC000000000, *((BITCHUNK *)g_pheap));
+	free(addr100);
+	assert_equal(0xFF00000000000000, *((BITCHUNK *)g_pheap));
+
+	// acquiring all memory
+	void *addrAll = malloc(4096 - 9 * 8);
+	assert_addr_equal(addrAll, WORD(g_pheap) + 8 + 1);
+	BITCHUNK *bitchunk = (BITCHUNK *)g_pheap;
+	// all bits should be turned on.
+	for (int i = 0; i < 8; ++i) assert_equal(bitchunk[i], ~0x0);
+	// the first word should contain the boundary tag.
+	assert_equal(0xBBEEEEFF, *((U32 *)(WORD(addrAll) - 1)));
+	assert_equal(504, ((U32 *)(WORD(addrAll) - 1))[1]);
 }
 
 int main(int argc, char *argv[]) {

--- a/bitmap/bitmap_basic_tests.c
+++ b/bitmap/bitmap_basic_tests.c
@@ -48,10 +48,36 @@ void test_bitmap_malloc() {
 	// check bit board
 	assert_equal(0xFFE0000000000000, *((BITCHUNK *)g_pheap));
 	// check address
-	assert_addr_equal(addr10, g_pheap + 8 + 1);
+	assert_addr_equal(addr10, WORD(g_pheap) + 8 + 1);
 	// check boundary tag
-	assert_equal(0xBBEEEEFF, *((U32 *)(addr10 - 1)));
-	assert_equal(3, ((U32 *)(addr10 - 1))[1]);
+	assert_equal(0xBBEEEEFF, *((U32 *)(WORD(addr10) - 1)));
+	assert_equal(3, ((U32 *)(WORD(addr10) - 1))[1]);
+}
+
+void test_bitmap_malloc_free() {
+	//////////
+	void *addr20 = malloc(20);
+	// check bit board
+	assert_equal(0xFFF0000000000000, *((BITCHUNK *)g_pheap));
+	// check address
+	assert_addr_equal(addr20, WORD(g_pheap) + 8 + 1);
+	// check boundary tag
+	assert_equal(0xBBEEEEFF, *((U32 *)(WORD(addr20) - 1)));
+	assert_equal(4, ((U32 *)(WORD(addr20) - 1))[1]);
+	//////////
+	void *addr100 = malloc(100);
+	// check bit board
+	assert_equal(0xFFFFFFC000000000, *((BITCHUNK *)g_pheap));
+	// check address
+	assert_addr_equal(addr100, WORD(g_pheap) + 12 + 1);
+	// check boundary tag
+	assert_equal(0xBBEEEEFF, *((U32 *)(WORD(addr100) - 1)));
+	assert_equal(14, ((U32 *)(WORD(addr100) - 1))[1]);
+	///////////
+	// freeing
+	free(addr20);
+	// check bit board
+	assert_equal(0xFF0FFFC000000000, *((BITCHUNK *)g_pheap));
 }
 
 int main(int argc, char *argv[]) {
@@ -60,6 +86,7 @@ int main(int argc, char *argv[]) {
 
 	test(test_bitmap_init);
 	test(test_bitmap_malloc);
+	test(test_bitmap_malloc_free);
 
 	return 0;
 }

--- a/bitmap/bitmap_replay.c
+++ b/bitmap/bitmap_replay.c
@@ -1,0 +1,62 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2015 Terence Parr, Hanzhou Shi, Shuai Yuan, Yuanyuan Zhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <cunit.h>
+#include <time.h>
+
+#include "replay.h"
+#include "bitmap.h"
+
+const size_t HEAP_SIZE = 1000000000; // try 1G
+
+static void setup()		{ bitmap_init(HEAP_SIZE); }
+static void teardown()	{ /*verify_heap();*/ bitmap_release(); }
+
+void replay_ansic_grammar_with_dparser() {
+	int result = replay_malloc("/tmp/trace.txt");
+	assert_equal(0, result);
+}
+
+int main(int argc, char *argv[]) {
+	// TODO: currently must run from cmd-line: no way to set working dir in cmake?
+	printf("converting addresses to indexes\n");
+	system("python ../cunit/addr2index.py < ../cunit/ANSIC_MALLOC_FREE_TRACE.txt > /tmp/trace.txt");
+	printf("simulating...\n");
+
+	cunit_setup = setup;
+	cunit_teardown = teardown;
+
+	bitmap_init(HEAP_SIZE);
+	{
+		time_t start = time(NULL);
+		test(replay_ansic_grammar_with_dparser);
+		time_t stop = time(NULL);
+
+		fprintf(stderr, "simulation took %ldms\n", (stop-start));
+	}
+
+	return 0;
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,5 +5,7 @@ set(MODULE_NAME malloc)
 set(SOURCE morecore.c bitset.c)
 add_library(${MODULE_NAME} ${SOURCE})
 target_link_libraries(${MODULE_NAME} cunit)
+set_target_properties(${MODULE_NAME} PROPERTIES
+		COMPILE_FLAGS "-mpopcnt -mlzcnt")
 
 ADD_TEST_TARGET(bitset_basic_tests ${MODULE_NAME})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -6,6 +6,7 @@ set(SOURCE morecore.c bitset.c)
 add_library(${MODULE_NAME} ${SOURCE})
 target_link_libraries(${MODULE_NAME} cunit)
 set_target_properties(${MODULE_NAME} PROPERTIES
-		COMPILE_FLAGS "-mpopcnt -mlzcnt")
-
+		COMPILE_FLAGS "-mpopcnt")
+#set_target_properties(${MODULE_NAME} PROPERTIES
+#COMPILE_FLAGS "-mpopcnt -mlzcnt")
 ADD_TEST_TARGET(bitset_basic_tests ${MODULE_NAME})

--- a/lib/bitset.c
+++ b/lib/bitset.c
@@ -43,7 +43,7 @@ static inline size_t bs_lzcnt(BITCHUNK bchk) {
 static inline size_t bs_tzcnt(BITCHUNK bchk) {
 	// in Core i7 processors this intrinsic is translated to
 	// BSF, thus gives the first index of a set bit.
-	
+
 	// TODO currently the clang flag is turned for this intrinsic.
 	// TODO not actually using LZCNT instruction. and it has a weird
 	// TODO optimization when using clang, try with gcc later.

--- a/lib/bitset.h
+++ b/lib/bitset.h
@@ -27,15 +27,15 @@ SOFTWARE.
 
 #include <stddef.h>
 
-typedef unsigned long long      BITCHUNK;
+typedef unsigned long long      BITCHUNK;// one full chunk covers 512 bytes in the heap.
 typedef unsigned char           U1;
 
+#define BITSET_NON              ((BITCHUNK) ~0x0)// we can never get that much memory
 #define BIT_NUM                 8
 #define WORD_SIZE               (sizeof(void *))
 #define ALIGN_MASK              (WORD_SIZE - 1)
 #define CHUNK_SIZE              (sizeof(BITCHUNK))// usually it's the same as WORD_SIZE on 64-bit machines.
 #define CHK_IN_BIT      (CHUNK_SIZE * BIT_NUM)
-#define CHUNK_ALIGN_MASK        (CHK_IN_BIT - 1)
 #define BC_ONE                  0xFFFFFFFFFFFFFFFF
 #define BC_LEFTMOST_MASK        0x8000000000000000
 

--- a/lib/bitset.h
+++ b/lib/bitset.h
@@ -29,6 +29,7 @@ SOFTWARE.
 
 typedef unsigned long long      BITCHUNK;// one full chunk covers 512 bytes in the heap.
 typedef unsigned char           U1;
+typedef __uint32_t              U32;
 
 #define BITSET_NON              ((BITCHUNK) ~0x0)// we can never get that much memory
 #define BIT_NUM                 8

--- a/lib/bitset.h
+++ b/lib/bitset.h
@@ -31,12 +31,13 @@ typedef unsigned long long      BITCHUNK;// one full chunk covers 512 bytes in t
 typedef unsigned char           U1;
 typedef __uint32_t              U32;
 
+#define WORD(x)                 ((unsigned long long *)x)
 #define BITSET_NON              ((BITCHUNK) ~0x0)// we can never get that much memory
 #define BIT_NUM                 8
 #define WORD_SIZE               (sizeof(void *))
 #define ALIGN_MASK              (WORD_SIZE - 1)
 #define CHUNK_SIZE              (sizeof(BITCHUNK))// usually it's the same as WORD_SIZE on 64-bit machines.
-#define CHK_IN_BIT      (CHUNK_SIZE * BIT_NUM)
+#define CHK_IN_BIT              (CHUNK_SIZE * BIT_NUM)
 #define BC_ONE                  0xFFFFFFFFFFFFFFFF
 #define BC_LEFTMOST_MASK        0x8000000000000000
 

--- a/lib/bitset.h
+++ b/lib/bitset.h
@@ -33,14 +33,11 @@ typedef unsigned char           U1;
 #define BIT_NUM                 8
 #define WORD_SIZE               (sizeof(void *))
 #define ALIGN_MASK              (WORD_SIZE - 1)
-#define CHUNK_SIZE              (sizeof(BITCHUNK))
-#define CHUNK_SIZE_IN_BITS      (CHUNK_SIZE * BIT_NUM)
-#define CHUNK_ALIGN_MASK        (CHUNK_SIZE_IN_BITS - 1)
+#define CHUNK_SIZE              (sizeof(BITCHUNK))// usually it's the same as WORD_SIZE on 64-bit machines.
+#define CHK_IN_BIT      (CHUNK_SIZE * BIT_NUM)
+#define CHUNK_ALIGN_MASK        (CHK_IN_BIT - 1)
 #define BC_ONE                  0xFFFFFFFFFFFFFFFF
 #define BC_LEFTMOST_MASK        0x8000000000000000
-
-#define ROUND_UP(n)             ((n & CHUNK_ALIGN_MASK) == 0 ? n : (n + CHUNK_SIZE_IN_BITS) & ~CHUNK_ALIGN_MASK)
-#define ROUND_DOWN(n)           ((((n + 1) & CHUNK_ALIGN_MASK) == 0) ? (n + 1) : (n & ~CHUNK_ALIGN_MASK))
 
 #define ALIGN_WORD_BOUNDARY(n)  ((n & ALIGN_MASK) == 0 ? n : (n + WORD_SIZE) & ~ALIGN_MASK)
 
@@ -57,10 +54,14 @@ typedef unsigned char           U1;
 #define LUP_ROW 256
 #define LUP_COL 8
 static int ff_lup[LUP_ROW][LUP_COL];
+static int lz_lup[LUP_ROW];
+static int tz_lup[LUP_ROW];
+
 /*
  * the initial masks with n leading 0s (from left).
  */
-static unsigned char n_leading0[8] = {0x7f, 0x3f, 0x1f, 0x0f, 0x07, 0x03, 0x01, 0x00};
+static unsigned char n_lz_mask[LUP_COL] = {0x7f, 0x3f, 0x1f, 0x0f, 0x07, 0x03, 0x01, 0x00};
+static unsigned char n_tz_mask[LUP_COL] = {0xfe, 0xfc, 0xf8, 0xf0, 0xe0, 0xc0, 0x80, 0x00};
 static BITCHUNK right_masks[65];
 static BITCHUNK left_masks[65];
 
@@ -73,9 +74,10 @@ typedef struct {
 } bitset;
 
 void bs_init(bitset *, size_t, void *);
-int bs_nrun(bitset *, size_t);
+size_t bs_nrun(bitset *, size_t);
 int bs_set1(bitset *, size_t, size_t);
 int bs_set0(bitset *, size_t, size_t);
+int bs_chk_scann(BITCHUNK, size_t);
 
 void bs_dump(BITCHUNK, int);
 

--- a/lib/bitset_basic_tests.c
+++ b/lib/bitset_basic_tests.c
@@ -40,7 +40,7 @@ void test_bs_init() {
 	bitset bs;
 	bs_init(&bs, 2, g_heap);
 	assert_equal(bs.m_bc[0], 0xC000000000000000);
-	assert_equal(bs.m_bc[1], 0ULL);
+	assert_equal(bs.m_bc[1], 0x0);
 }
 
 void test_bs_set1() {
@@ -73,6 +73,23 @@ void test_bs_set1_right_boundary_lo() {
 	bs_set1(&bs, 63, 77);
 	assert_equal(bs.m_bc[0], 0xC000000000000001);
 	assert_equal(bs.m_bc[1], 0xFFFC000000000000);
+}
+
+void test_bs_set1_same_chk() {
+	bitset bs;
+	bs_init(&bs, 2, g_heap);
+	assert_equal(bs.m_bc[0], 0xC000000000000000);
+	bs_set1(&bs, 2, 3);
+	assert_equal(bs.m_bc[0], 0xF000000000000000);
+}
+
+void test_bs_set1_same_chk_middle() {
+	bitset bs;
+	bs_init(&bs, 2, g_heap);
+	assert_equal(bs.m_bc[0], 0xC000000000000000);
+	bs_set1(&bs, 23, 33);
+	assert_equal(bs.m_bc[0], 0xC00001FFC0000000);
+	assert_equal(bs.m_bc[1], 0x0);
 }
 
 void test_bs_set0() {
@@ -111,6 +128,48 @@ void test_bs_set0_right_boundary_lo() {
 	assert_equal(bs.m_bc[1], 0x0003800000000000);
 }
 
+void test_bs_set0_same_chk() {
+	bitset bs;
+	bs_init(&bs, 2, g_heap);
+	bs_set1(&bs, 23, 63);//  0xC00001FFFFFFFFFF
+	bs_set0(&bs, 24, 33);
+	assert_equal(bs.m_bc[0], 0xC00001003FFFFFFF);
+	assert_equal(bs.m_bc[1], 0x0);
+}
+
+void test_bs_chk_scann() {
+	BITCHUNK bchk = 0xFFFFF1FFFFFFF011;
+	int index7 = bs_chk_scann(bchk, 7);
+	int index4 = bs_chk_scann(bchk, 4);
+	int index3 = bs_chk_scann(bchk, 3);
+	int index10 = bs_chk_scann(bchk, 10);
+	assert_equal(52, index7);
+	assert_equal(52, index4);
+	assert_equal(20, index3);
+	assert_equal(-1, index10);
+}
+
+void test_bs_chk_scann_left_bdry() {
+	BITCHUNK bchk = 0x0100000000000000;
+	int index7 = bs_chk_scann(bchk, 7);
+	assert_equal(0, index7);
+}
+
+void test_bs_chk_scann_right_bdry() {
+	BITCHUNK bchk = 0xFFFFFFFFFFFFFF80;
+	int index7 = bs_chk_scann(bchk, 7);
+	assert_equal(57, index7);
+}
+
+void test_bs_nrun() {
+	bitset bs;
+	bs_init(&bs, 2, g_heap);
+	size_t index2 = bs_nrun(&bs, 2);
+	assert_equal(2, index2);
+	size_t index12 = bs_nrun(&bs, 12);
+	assert_equal(4, index12);
+}
+
 int main(int argc, char *argv[]) {
 	cunit_setup = setup;
 	cunit_teardown = teardown;
@@ -120,10 +179,19 @@ int main(int argc, char *argv[]) {
 	test(test_bs_set1_left_boundary);
 	test(test_bs_set1_right_boundary_hi);
 	test(test_bs_set1_right_boundary_lo);
+	test(test_bs_set1_same_chk);
+	test(test_bs_set1_same_chk_middle);
 	test(test_bs_set0);
 	test(test_bs_set0_left_boundary);
 	test(test_bs_set0_right_boundary_hi);
 	test(test_bs_set0_right_boundary_lo);
+	test(test_bs_set0_same_chk);
+
+	test(test_bs_chk_scann);
+	test(test_bs_chk_scann_left_bdry);
+	test(test_bs_chk_scann_right_bdry);
+
+	test(test_bs_nrun);
 
 	return 0;
 }

--- a/lib/bitset_basic_tests.c
+++ b/lib/bitset_basic_tests.c
@@ -163,11 +163,87 @@ void test_bs_chk_scann_right_bdry() {
 
 void test_bs_nrun() {
 	bitset bs;
+	// initialization
 	bs_init(&bs, 2, g_heap);
+	assert_equal(bs.m_bc[0], 0xC000000000000000);
+	// try acquiring the 3rd and 4th bits.
 	size_t index2 = bs_nrun(&bs, 2);
 	assert_equal(2, index2);
+	assert_equal(bs.m_bc[0], 0xF000000000000000);
+	// try acquiring next 12 bits.
 	size_t index12 = bs_nrun(&bs, 12);
 	assert_equal(4, index12);
+	assert_equal(bs.m_bc[0], 0xFFFF000000000000);//16 1s
+	// setting the last 33 bits of the first chunk
+	// to 1 such that we can get the next trunk for allocation
+	// of 16 bits. there are only 15 bits left for the first
+	// chunk now.
+	bs_set1(&bs, 31, 63);
+	size_t index16 = bs_nrun(&bs, 16);
+	assert_equal(64, index16);
+	assert_equal(bs.m_bc[1], 0xFFFF000000000000);
+	// get the 15 bits left in the first chunk.
+	size_t index15 = bs_nrun(&bs, 15);
+	assert_equal(16, index15);
+	assert_equal(bs.m_bc[0], 0xFFFFFFFFFFFFFFFF);
+	assert_equal(bs.m_bc[1], 0xFFFF000000000000);
+	// trying leading mode here
+	bs_set0(&bs, 50, 70);// set a 0 "island" cross two chunks
+	assert_equal(bs.m_bc[0], 0xFFFFFFFFFFFFC000);
+	assert_equal(bs.m_bc[1], 0x01FF000000000000);
+	size_t index19 = bs_nrun(&bs, 19);
+	assert_equal(50, index19);
+	assert_equal(bs.m_bc[0], 0xFFFFFFFFFFFFFFFF);
+	assert_equal(bs.m_bc[1], 0xF9FF000000000000);
+}
+
+void test_bs_nrun_long() {
+	bitset bs;
+	// 8 chks right covers 4096 bytes (our heap size).
+	bs_init(&bs, 8, g_heap);
+	// we need one full byte to cover 8 chunks
+	assert_equal(bs.m_bc[0], 0xFF00000000000000);
+
+	size_t index375 = bs_nrun(&bs, 375);
+	assert_equal(8, index375);
+	for (int i = 0; i < 5; ++i) {
+		// all chunks should be occupied right now.
+		assert_equal(bs.m_bc[i], ~0x0);
+	}
+	assert_equal(bs.m_bc[5], 0xFFFFFFFFFFFFFFFE);
+	// now the last two chunks with one extra bit should be 1s
+	bs_set1(&bs, 383, 511);
+	bs_set0(&bs, 8, 382);
+	for (int i = 1; i < 5; ++i) {
+		assert_equal(bs.m_bc[i], 0x0);
+	}
+	assert_equal(bs.m_bc[0], 0xFF00000000000000);
+	assert_equal(bs.m_bc[5], 0x0000000000000001);
+	assert_equal(bs.m_bc[6], 0xFFFFFFFFFFFFFFFF);
+	assert_equal(bs.m_bc[7], 0xFFFFFFFFFFFFFFFF);
+
+	// trying to get a chunk that is longer than available
+	size_t index376 = bs_nrun(&bs, 376);
+	// nothing should change.
+	for (int i = 1; i < 5; ++i) {
+		assert_equal(bs.m_bc[i], 0x0);
+	}
+	assert_equal(bs.m_bc[0], 0xFF00000000000000);
+	assert_equal(bs.m_bc[5], 0x0000000000000001);
+	assert_equal(bs.m_bc[6], ~0x0);
+	assert_equal(bs.m_bc[7], ~0x0);
+	// returns BITSET NON since we only have 375 bits available
+	assert_equal(BITSET_NON, index376);
+
+	size_t index374 = bs_nrun(&bs, 374);
+	// now we should only have one bit available.
+	assert_equal(8, index374);
+	for (int i = 0; i < 5; ++i) {
+		assert_equal(bs.m_bc[i], ~0x0);
+	}
+	assert_equal(bs.m_bc[5], 0xFFFFFFFFFFFFFFFD);
+	assert_equal(bs.m_bc[6], ~0x0);
+	assert_equal(bs.m_bc[7], ~0x0);
 }
 
 int main(int argc, char *argv[]) {
@@ -192,6 +268,7 @@ int main(int argc, char *argv[]) {
 	test(test_bs_chk_scann_right_bdry);
 
 	test(test_bs_nrun);
+	test(test_bs_nrun_long);
 
 	return 0;
 }


### PR DESCRIPTION
1. Implemented function to find "n-run" of 0 bits.
2. Added more test cases.
3. The compiler flag to use the actual bitscan instructions is now turned off because of the weird side-effect we saw today, will try with GCC after the compilation finishes ;)
4. Added implementation of malloc.
5. Added implementation of free  and test cases.
